### PR TITLE
Fix typo, docs, stylesheet import, and strengthen smoke test

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A simple SPA Portfolio template for developer/designers built with React and Vit
 ## How to use
 1. Clone/Download the repo.
 2. Run  ``` npm install ```.
-3. Change the values in ```src/resumeData.js``` to suit your use-case.
-4. Run ```npm start``` to spin the up the local dev server port 3000.(http://localhost:3000).
-5. Make required changes in ```src/resumeData.js``` to suit your needs.
+3. Change the values in ```src/resumeData.jsx``` to suit your use-case.
+4. Run ```npm run dev``` to start the Vite dev server (http://localhost:5173 by default).
+5. Make any additional updates in ```src/resumeData.jsx``` or the components to suit your needs.
 

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,9 +1,41 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { createRoot } from 'react-dom/client';
+import { act } from 'react-dom/test-utils';
 import App from './App';
 
-it('renders without crashing', () => {
-  const div = document.createElement('div');
-  ReactDOM.render(<App />, div);
-  ReactDOM.unmountComponentAtNode(div);
+describe('App', () => {
+  let container;
+  let root;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+    container = null;
+  });
+
+  it('renders key sections from the portfolio', () => {
+    act(() => {
+      root.render(<App />);
+    });
+
+    const aboutHeading = container.querySelector('#about h2');
+    expect(aboutHeading).not.toBeNull();
+    expect(aboutHeading.textContent).toBe('About Me');
+
+    const portfolioHeading = container.querySelector('#portfolio h1');
+    expect(portfolioHeading).not.toBeNull();
+    expect(portfolioHeading.textContent).toBe('Samples of Work');
+
+    const contactHeading = container.querySelector('#contact h1 span');
+    expect(contactHeading).not.toBeNull();
+    expect(contactHeading.textContent).toBe('Let\u2019s Connect');
+  });
 });

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import './index.css';
-import 'react-image-lightbox/style.css';
+import 'yet-another-react-lightbox/styles.css';
 import App from './App';
 import * as serviceWorker from './serviceWorker';
   

--- a/src/resumeData.jsx
+++ b/src/resumeData.jsx
@@ -132,7 +132,7 @@ let resumeData = {
       {
         "id":"Profoundlogic",
         "name":"Profoundlogic.com",
-        "description":"Profound Logic Software main site I redesigned in 2020. UI/UX redesign of the fornt page with fresh icons and a three part layout at the bottom with core features.",
+        "description":"Profound Logic Software main site I redesigned in 2020. UI/UX redesign of the front page with fresh icons and a three part layout at the bottom with core features.",
         "url":"https://www.profoundlogic.com",
         "imgurl":"images/portfolio/plcom.webp",
         "alt":"profoundlogic.com"
@@ -166,7 +166,7 @@ let resumeData = {
       {
         "id":"Profoundlogic1",
         "name":"Profoundlogic.com Redesign 2020",
-        "description":"Profound Logic Software main site I redesigned in 2020. UI/UX redesign of the fornt page with fresh icons and a three part layout at the bottom with core features.",
+        "description":"Profound Logic Software main site I redesigned in 2020. UI/UX redesign of the front page with fresh icons and a three part layout at the bottom with core features.",
         "url":"https://web.archive.org/web/20210808202810/https:/www.profoundlogic.com/",
         "imgurl":"images/portfolio/Profoundlogic1.webp",
         "alt":"profoundlogic.com-2020"


### PR DESCRIPTION
## Summary
- correct the "fornt" typo in the portfolio project descriptions
- swap the removed lightbox stylesheet import for the current package
- align the README instructions with the Vite data file and dev command
- expand the App smoke test to assert key sections render

## Testing
- not run (project has no test script)


------
https://chatgpt.com/codex/tasks/task_e_68e831ab2f04832eb6779469b810a85f