### PR TITLE
Improve accessibility for WCAG 2.2

### DIFF
--- a/public/css/layout.css
+++ b/public/css/layout.css
@@ -820,6 +820,22 @@ header .social li a:hover{
   border-radius: 6px;
 }
 
+.skip-link{
+  position:absolute;
+  top:-40px;
+  left:16px;
+  padding:10px 16px;
+  background:#111;
+  color:#fff;
+  border-radius:6px;
+  z-index:1000;
+  transition: top .2s ease;
+}
+
+.skip-link:focus{
+  top:16px;
+}
+
 /* Respect reduced motion */
 @media (prefers-reduced-motion: reduce){
   *{ animation-duration: .001ms !important; animation-iteration-count: 1 !important; transition-duration: .001ms !important; scroll-behavior: auto !important; }
@@ -1148,6 +1164,15 @@ footer .privacy { color: #9a9a9a; font-size: 0.9rem; }
 #testimonials .t-slide{ display:none; }
 #testimonials .t-slide.is-active{ display:block; }
 
+#testimonials .t-controls{
+  display:flex;
+  justify-content:center;
+  align-items:center;
+  gap:16px;
+  margin-top:16px;
+  flex-wrap:wrap;
+}
+
 #testimonials blockquote{
   margin:0 auto; max-width:700px; text-align:left;
 }
@@ -1166,6 +1191,24 @@ footer .privacy { color: #9a9a9a; font-size: 0.9rem; }
 #testimonials .t-dots button.is-active{ background:#fff; }
 #testimonials .t-dots button:focus-visible{
   outline:2px solid #79d1ff; outline-offset:2px;
+}
+
+#testimonials .t-pause{
+  border:0;
+  padding:10px 18px;
+  border-radius:999px;
+  background:#2a2a2a;
+  color:#fff;
+  font-size:0.95rem;
+  cursor:pointer;
+  transition: background .25s ease, color .25s ease, transform .15s ease;
+}
+
+#testimonials .t-pause:hover,
+#testimonials .t-pause:focus-visible{
+  background: var(--brand);
+  color:#0d0d0d;
+  transform: translateY(-1px);
 }
 
 /* helper to hide text for screen-reader-only content */

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -13,12 +13,20 @@ class App extends Component {
   render() {
     return (
       <div className="App">
+        <a href="#main-content" className="skip-link">
+          Skip to main content
+        </a>
+
         <Header resumeData={resumeData}/>
-        <About resumeData={resumeData}/>
-        <Portfolio resumeData={resumeData}/>
-        <Resume resumeData={resumeData}/>
-        <Testimonials resumeData={resumeData}/>
-        <ContactUs resumeData={resumeData}/>
+
+        <main id="main-content" tabIndex="-1">
+          <About resumeData={resumeData}/>
+          <Portfolio resumeData={resumeData}/>
+          <Resume resumeData={resumeData}/>
+          <Testimonials resumeData={resumeData}/>
+          <ContactUs resumeData={resumeData}/>
+        </main>
+
         <Footer resumeData={resumeData}/>
       </div>
     );

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -150,6 +150,7 @@ const Header = ({ resumeData = {} }) => {
           id="nav-wrap"
           className={navClassName}
           aria-expanded={isMobile ? navOpen : undefined}
+          aria-label="Primary navigation"
         >
           {isMobile && (
             <button

--- a/src/components/Testimonials.jsx
+++ b/src/components/Testimonials.jsx
@@ -10,12 +10,64 @@ const QuoteIcon = (props) => (
 export default function Testimonials({ resumeData }) {
   const testimonials = resumeData?.testimonials || [];
   const [current, setCurrent] = useState(0);
+  const [isPaused, setIsPaused] = useState(false);
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
+
+  const hasMultipleSlides = testimonials.length > 1;
 
   useEffect(() => {
-    if (!testimonials.length) return;
-    const id = setInterval(() => setCurrent((i) => (i + 1) % testimonials.length), 6000);
-    return () => clearInterval(id);
-  }, [testimonials.length]);
+    if (typeof window === "undefined" || !window.matchMedia) return undefined;
+
+    const mediaQuery = window.matchMedia("(prefers-reduced-motion: reduce)");
+    const updatePreference = (event) => {
+      setPrefersReducedMotion(event.matches);
+    };
+
+    updatePreference(mediaQuery);
+
+    if (mediaQuery.addEventListener) {
+      mediaQuery.addEventListener("change", updatePreference);
+    } else {
+      mediaQuery.addListener(updatePreference);
+    }
+
+    return () => {
+      if (mediaQuery.removeEventListener) {
+        mediaQuery.removeEventListener("change", updatePreference);
+      } else {
+        mediaQuery.removeListener(updatePreference);
+      }
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!testimonials.length || !hasMultipleSlides || isPaused || prefersReducedMotion) {
+      return undefined;
+    }
+
+    const id = window.setInterval(() => {
+      setCurrent((i) => (i + 1) % testimonials.length);
+    }, 6000);
+
+    return () => {
+      window.clearInterval(id);
+    };
+  }, [hasMultipleSlides, isPaused, prefersReducedMotion, testimonials.length]);
+
+  useEffect(() => {
+    if (current >= testimonials.length) {
+      setCurrent(0);
+    }
+  }, [current, testimonials.length]);
+
+  const goToSlide = (idx) => {
+    setCurrent(idx);
+    setIsPaused(true);
+  };
+
+  const togglePause = () => {
+    setIsPaused((prev) => !prev);
+  };
 
   if (!testimonials.length) return null;
 
@@ -28,39 +80,75 @@ export default function Testimonials({ resumeData }) {
           </div>
 
           <div className="ten columns">
-            <div className="t-rotator" role="region" aria-live="polite">
-              <ul className="t-slides">
-                {testimonials.map((t, idx) => (
-                  <li
-                    key={t.id || idx}
-                    className={`t-slide ${idx === current ? "is-active" : ""}`}
-                    aria-hidden={idx === current ? "false" : "true"}
-                  >
-                    <blockquote>
-                      <QuoteIcon style={{ opacity: .7, marginBottom: 8 }} />
-                      <p>{t.description}</p>
-                      <cite>
-                        {t.name} <em>{t.role}</em> — {t.company}
-                      </cite>
-                    </blockquote>
-                  </li>
-                ))}
+            <div
+              className="t-rotator"
+              role="region"
+              aria-live={prefersReducedMotion ? "off" : "polite"}
+              aria-atomic="true"
+            >
+              <ul className="t-slides" aria-label="Testimonials">
+                {testimonials.map((t, idx) => {
+                  const slideId = `t-slide-${idx}`;
+                  const tabId = `t-tab-${idx}`;
+                  const isActive = idx === current;
+
+                  return (
+                    <li
+                      key={t.id || idx}
+                      id={slideId}
+                      className={`t-slide ${isActive ? "is-active" : ""}`}
+                      aria-labelledby={tabId}
+                      hidden={!isActive}
+                    >
+                      <blockquote>
+                        <QuoteIcon style={{ opacity: .7, marginBottom: 8 }} />
+                        <p>{t.description}</p>
+                        <cite>
+                          {t.name} <em>{t.role}</em> — {t.company}
+                        </cite>
+                      </blockquote>
+                    </li>
+                  );
+                })}
               </ul>
 
-              <div className="t-dots" role="tablist" aria-label="Testimonial slides">
-                {testimonials.map((_, idx) => (
-                  <button
-                    key={idx}
-                    role="tab"
-                    aria-selected={idx === current}
-                    aria-controls={`t-slide-${idx}`}
-                    onClick={() => setCurrent(idx)}
-                    className={idx === current ? "is-active" : ""}
-                  >
-                    <span className="sr-only">Go to slide {idx + 1}</span>
-                  </button>
-                ))}
-              </div>
+              {hasMultipleSlides && (
+                <div className="t-controls">
+                  <div className="t-dots" role="group" aria-label="Select a testimonial">
+                    {testimonials.map((_, idx) => {
+                      const tabId = `t-tab-${idx}`;
+                      const slideId = `t-slide-${idx}`;
+                      const isActive = idx === current;
+
+                      return (
+                        <button
+                          key={idx}
+                          id={tabId}
+                          type="button"
+                          aria-controls={slideId}
+                          aria-current={isActive ? "true" : undefined}
+                          onClick={() => goToSlide(idx)}
+                          className={isActive ? "is-active" : ""}
+                        >
+                          <span className="sr-only">Go to slide {idx + 1}</span>
+                        </button>
+                      );
+                    })}
+                  </div>
+
+                  {!prefersReducedMotion && (
+                    <button
+                      type="button"
+                      className="t-pause"
+                      onClick={togglePause}
+                      aria-pressed={isPaused}
+                      aria-label={isPaused ? "Resume testimonial rotation" : "Pause testimonial rotation"}
+                    >
+                      {isPaused ? "Resume" : "Pause"}
+                    </button>
+                  )}
+                </div>
+              )}
             </div>
           </div>
 


### PR DESCRIPTION
## Summary
- add a skip link and main landmark so keyboard users can bypass the masthead
- label the primary navigation and enhance testimonial controls with pause/resume and reduced motion support
- style the new accessibility affordances including skip link and testimonial controls

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68fc4f2c5078832e81278a779b14b370